### PR TITLE
SCR1 Patches (No Bursts)

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -2851,7 +2851,11 @@ static bool mem_should_skip_progbuf(struct target *target, target_addr_t address
 		return true;
 	}
 
-	return false;
+	// Disable all bursts regardless if read or write
+	LOG_INFO("Skipping mem %s via progbuf - as bursts are somewhat broken with SCR1.",
+	         read ? "read" : "write");
+	*skip_reason = "Bursts seem to be broken with SCR1";
+	return true;
 }
 
 static bool mem_should_skip_sysbus(struct target *target, target_addr_t address,


### PR DESCRIPTION
This adds required patches to make debugging with SCR1 work.
These disable all read & write bursts as workaround.
An own branch might be desirable, the PR target branch can be adjusted after its creation.