### PR TITLE
SCR1 Patches (Only Write Bursts)

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -2851,6 +2851,14 @@ static bool mem_should_skip_progbuf(struct target *target, target_addr_t address
 		return true;
 	}
 
+	if (read) {
+		// Write bursts work, so just skip read bursts
+		LOG_INFO("Skipping mem %s via progbuf - as bursts are somewhat broken with SCR1.",
+				read ? "read" : "write");
+		*skip_reason = "Read bursts seem to be broken with SCR1";
+		return true;
+	}
+
 	return false;
 }
 


### PR DESCRIPTION
This adds required patches to make debugging with SCR1 work.
These disable all read bursts but leave write bursts untouched as workaround.
An own branch might be desirable, the PR target branch can be adjusted after its creation.